### PR TITLE
修复BaseService中分页查询缺少参数的问题

### DIFF
--- a/app/BaseService.php
+++ b/app/BaseService.php
@@ -29,9 +29,9 @@ abstract class BaseService
         return $this->model->all();
     }
 
-    public function paginate()
+    public function paginate($limit)
     {
-        return $this->model->paginate();
+        return $this->model->paginate($limit);
     }
 
     public function add(array $input)


### PR DESCRIPTION
BaseModel中paginate函数需要一个参数。